### PR TITLE
Change featured images to scroll with content

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -104,17 +104,19 @@ main {
 
 /* Featured image styles for single posts */
 .featured-image {
-    margin: 1.5rem 0;
+    margin: 2rem 0;
     text-align: center;
+    position: relative;
 }
 
 .featured-image img {
     width: 100%;
-    max-width: 400px;
-    height: 250px;
-    object-fit: cover;
+    max-width: 100%;
+    height: auto;
     border-radius: 8px;
-    box-shadow: 0 0 2px 0 rgba(0,0,0,0.15);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    display: block;
+    margin: 0 auto;
 }
 
 .post-item {
@@ -616,9 +618,14 @@ footer {
 }
 
 @media (max-width: 480px) {
+    .featured-image {
+        margin: 1.5rem 0;
+    }
+    
     .featured-image img {
-        max-width: 300px;
-        height: 200px;
+        max-width: 100%;
+        height: auto;
+        border-radius: 6px;
     }
     
     .post h1 {


### PR DESCRIPTION
Update featured image styling to scroll naturally with content instead of appearing fixed.

The original styling caused featured images on post detail pages to appear fixed and hover over content. This PR adjusts the CSS to ensure images flow with the document, scale responsively, and maintain their aspect ratio.